### PR TITLE
🐛 — Fix ep_mediawiki export

### DIFF
--- a/ep_mediawiki/exportMediaWiki.js
+++ b/ep_mediawiki/exportMediaWiki.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import {StringAssembler} from "ep_etherpad-lite/static/js/StringAssembler";
+import {StringIterator} from "ep_etherpad-lite/static/js/StringIterator";
 const Changeset = require('ep_etherpad-lite/static/js/Changeset');
 const padManager = require('ep_etherpad-lite/node/db/PadManager');
 
@@ -42,8 +44,8 @@ const getMediaWikiFromAtext = (pad, atext) => {
     // <b>Just bold<b> <b><i>Bold and italics</i></b> <i>Just italics</i>
     // becomes
     // <b>Just bold <i>Bold and italics</i></b> <i>Just italics</i>
-    const taker = Changeset.stringIterator(text);
-    const assem = Changeset.stringAssembler();
+    const taker = new StringIterator(text);
+    const assem = new StringAssembler();
 
     const emitOpenTag = (i) => {
       if (tags[i].indexOf('>') !== -1) {


### PR DESCRIPTION
Broken since https://github.com/ether/etherpad-lite/commit/28e04bdf71ae3e25d77f39900e2ff540c1d9c4d1 which removed stringAssembler and stringIterator from static/js/Changeset.ts.