### PR TITLE
🩹 — [ep_headings2] Add fallback font-policy for code in stylesForExport

### DIFF
--- a/ep_headings2/index.js
+++ b/ep_headings2/index.js
@@ -15,7 +15,7 @@ exports.stylesForExport = () => (
   'h2{font-size: 1.8em;}\n' +
   'h3{font-size: 1.5em;}\n' +
   'h4{font-size: 1.2em;}\n' +
-  'code{font-family: RobotoMono;}\n');
+  'code{font-family: RobotoMono, mono;}\n');
 
 const _analyzeLine = (alineAttrs, apool) => {
   let header = null;


### PR DESCRIPTION
On HTML export, if you don’t have `RobotoMono`, the `<code>` blocks uses serif font.

Adding a `mono` fallback after `RobotoMono` allows to have a correct font.